### PR TITLE
Wiki search and result

### DIFF
--- a/django_project_491/django_app/test.py
+++ b/django_project_491/django_app/test.py
@@ -1,5 +1,7 @@
+import json
 from django.test import TestCase
 from .Utils.utils import run_code
+from .views import wiki_result, wiki_search
 
 
 class TestRunCode(TestCase):
@@ -29,3 +31,40 @@ print(a)
             for i in range(len(expected)):
                 self.assertTrue(outs[i].startswith(expected[i]))
             self.assertTrue(result['message'] == "Exited with error status 1")
+
+class TestSearchResult(TestCase):
+
+    # test that the wiki_search returns correct labels even for multi-word strings
+    def test_search_valid(self):
+        request = None
+        response = wiki_search(request, "Python Java")
+        response_dict = json.loads(response.content)
+        bindings = response_dict['results']['bindings']
+        language_labels = [binding['languageLabel']['value'] for binding in bindings]
+        self.assertTrue("Python 3" in language_labels)
+        self.assertTrue("Java 21" in language_labels)
+    
+    # test that an invalid search does not crash and returns just empty bindings
+    def test_search_invalid(self):
+        request = None
+        response = wiki_search(request, "this_is_not_a_language_1234@#")
+        response_dict = json.loads(response.content)
+        self.assertTrue(response_dict['results']['bindings']==[]) # empty bindings response expected
+    
+    # test the output of the wiki_result with a valid input
+    def test_result_valid(self):
+        request = None
+        response = wiki_result(request, "Q15777") # C programming language 
+        response_dict = json.loads(response.content)
+        print(response_dict['mainInfo'][0]['languageLabel'])
+        self.assertTrue(response_dict['mainInfo'][0]['languageLabel']['value']=='C')
+        self.assertTrue(response_dict['mainInfo'][0]['website']['value']=='https://www.iso.org/standard/74528.html')
+        self.assertTrue(response_dict['wikipedia']['title']== 'C (programming language)')
+
+    def test_result_invalid(self):
+        request = None
+        response = wiki_result(request, "Qabc") # invalid wiki id
+        response_dict = json.loads(response.content)
+        self.assertTrue(response_dict['mainInfo']==[])
+        self.assertTrue(response_dict['wikipedia']==[])
+        self.assertTrue(response_dict['instances']==[])

--- a/django_project_491/django_app/test.py
+++ b/django_project_491/django_app/test.py
@@ -56,7 +56,6 @@ class TestSearchResult(TestCase):
         request = None
         response = wiki_result(request, "Q15777") # C programming language 
         response_dict = json.loads(response.content)
-        print(response_dict['mainInfo'][0]['languageLabel'])
         self.assertTrue(response_dict['mainInfo'][0]['languageLabel']['value']=='C')
         self.assertTrue(response_dict['mainInfo'][0]['website']['value']=='https://www.iso.org/standard/74528.html')
         self.assertTrue(response_dict['wikipedia']['title']== 'C (programming language)')

--- a/django_project_491/django_app/urls.py
+++ b/django_project_491/django_app/urls.py
@@ -2,9 +2,7 @@ from django.urls import path
 from .views import *
 
 urlpatterns = [
-    path('query/', wikidata_query_view, name='wikidata_query'),
     path('run_code/', run_code_view, name='run_code'),
-    path('wikipedia/', wikipedia_data_views, name='wikipedia'),
     path('search/<str:search_strings>', wiki_search, name='wiki_search'),
     path('result/<str:wiki_id>', wiki_result, name='wiki_result'),
 ]

--- a/django_project_491/django_app/urls.py
+++ b/django_project_491/django_app/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import *
+from .views import search, wikidata_query_view, run_code_view, wikipedia_data_views
 
 urlpatterns = [
     path('query/', wikidata_query_view, name='wikidata_query'),
     path('run_code/', run_code_view, name='run_code'),
-    path('wikipedia/', wikipedia_data_views, name='wikipedia')
+    path('wikipedia/', wikipedia_data_views, name='wikipedia'),
+    path('search/<str:search_strings>', search, name='search'),
 ]

--- a/django_project_491/django_app/urls.py
+++ b/django_project_491/django_app/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import search, wikidata_query_view, run_code_view, wikipedia_data_views
+from .views import *
 
 urlpatterns = [
     path('query/', wikidata_query_view, name='wikidata_query'),
     path('run_code/', run_code_view, name='run_code'),
     path('wikipedia/', wikipedia_data_views, name='wikipedia'),
-    path('search/<str:search_strings>', search, name='search'),
+    path('search/<str:search_strings>', wiki_search, name='wiki_search'),
+    path('result/<str:wiki_id>', wiki_result, name='wiki_result'),
 ]

--- a/django_project_491/django_app/views.py
+++ b/django_project_491/django_app/views.py
@@ -94,11 +94,14 @@ def wiki_result(response, wiki_id):
 
     # Process the results to combine main info and instances
     instances = [result['instanceLabel']['value'] for result in instances_results['results']['bindings'] if 'instanceLabel' in result]
-
+    try:
+        wikipedia_data = wikipedia_data_views(wiki_id)
+    except:
+        wikipedia_data = []
     final_response = {
         'mainInfo': main_info_results['results']['bindings'],
         'instances': instances,
-        'wikipedia': wikipedia_data_views(wiki_id)
+        'wikipedia': wikipedia_data
     }
 
     return JsonResponse(final_response)

--- a/django_project_491/django_app/views.py
+++ b/django_project_491/django_app/views.py
@@ -6,7 +6,7 @@ from django.shortcuts import render, redirect
 from urllib.parse import quote
 
 # Used for initial search - returns 5 best matching wiki id's
-def search(request, search_strings):
+def wiki_search(request, search_strings):
     sparql = SPARQLWrapper("https://query.wikidata.org/sparql")
     
     search_terms = search_strings.split() # split into words
@@ -40,6 +40,71 @@ def search(request, search_strings):
     results = sparql.query().convert()
 
     return JsonResponse(results)
+
+def wiki_result(response, wiki_id):
+    sparql = SPARQLWrapper("https://query.wikidata.org/sparql")
+
+    # First query to get the main language information
+    query_main_info = f"""
+      SELECT ?language ?languageLabel ?wikipediaLink ?influencedByLabel ?publicationDate ?inceptionDate ?website
+      WHERE {{
+        BIND(wd:{wiki_id} AS ?language)
+
+        # Get the label of the language in English
+        ?language rdfs:label ?languageLabel.
+        FILTER(LANG(?languageLabel) = "en")
+
+        OPTIONAL {{ ?language wdt:P737 ?influencedBy. }}
+        OPTIONAL {{ ?language wdt:P577 ?publicationDate. }}
+        OPTIONAL {{ ?language wdt:P571 ?inceptionDate. }}
+        OPTIONAL {{ ?language wdt:P856 ?website. }}
+        OPTIONAL {{
+            ?wikipediaLink schema:about ?language;
+            schema:isPartOf <https://en.wikipedia.org/>.
+        }}
+
+        SERVICE wikibase:label {{ 
+          bd:serviceParam wikibase:language "en". 
+        }}
+      }}
+      LIMIT 1
+    """
+
+    sparql.setQuery(query_main_info)
+    sparql.setReturnFormat(JSON)
+    main_info_results = sparql.query().convert()
+
+    # Extract the language ID
+    language_id = f"wd:{wiki_id}"
+
+    # Second query to get all instances of the language, excluding "programming language"
+    query_instances = f"""
+      SELECT ?instance ?instanceLabel
+      WHERE {{
+        BIND({language_id} AS ?language)
+
+        # Get all instances of the language, excluding programming languages
+        ?language wdt:P31 ?instance.
+        OPTIONAL {{ ?instance rdfs:label ?instanceLabel. FILTER(LANG(?instanceLabel) = "en") }}
+        FILTER(?instance != wd:Q9143)  # Exclude programming language (wd:Q9143)
+      }}
+    """
+
+    sparql.setQuery(query_instances)
+    sparql.setReturnFormat(JSON)
+    instances_results = sparql.query().convert()
+
+    # Process the results to combine main info and instances
+    instances = [result['instanceLabel']['value'] for result in instances_results['results']['bindings'] if 'instanceLabel' in result]
+
+    # Prepare the final response
+    final_response = {
+        'mainInfo': main_info_results['results']['bindings'],
+        'instances': instances
+    }
+
+    return JsonResponse(final_response)
+
 
 
 def wikidata_query_view(request):


### PR DESCRIPTION
Wrote queries for wikidata searches - including multi string support, and detailed result response from wikidata. The result response contains title, creation date, influenced by tag, suggestions of similar languages according to "instance of" tag. The detailed list of tasks can be found at #222.

To test out, you may run the local server and try these URLs for search and result respectively:

http://127.0.0.1:8000/wikidata/search/<< Your Language Of Choice as a String >>
for example: http://127.0.0.1:8000/wikidata/search/python

http://127.0.0.1:8000/wikidata/result/<< Valid Wiki Id>>
for example: http://127.0.0.1:8000/wikidata/result/Q15777