### PR TITLE
added the url fetch_search_results_at_once in order to make things faster

### DIFF
--- a/django_project_491/django_app/urls.py
+++ b/django_project_491/django_app/urls.py
@@ -26,8 +26,9 @@ urlpatterns = [
     path('preferred_languages/', user_views.get_user_preferred_languages, name='preferred_languages'),
     path('get_top_five_contributors/', user_views.list_most_contributed_five_person, name='get_top_five_contributors'),
     
-    path('fetch_feed_at_once/<int:user_id>/', question_views.fetch_all_at_once, name='get_user_profile'),
-
+    path('fetch_feed_at_once/<int:user_id>/', question_views.fetch_all_feed_at_once, name='get_user_profile'),
+    path('fetch_search_results_at_once/<str:wiki_id>/<str:language>/<int:page_number>', question_views.fetch_search_results_at_once, name='fetch_search_results_at_once'),
+    
     path('get_question/<int:question_id>/', question_views.get_question_details, name='get_question'),
     path('question/<int:question_id>/comments/', question_views.get_question_comments, name='get_question_comments'),
     path('create_question/', question_views.create_question, name='create_question'),
@@ -84,9 +85,4 @@ urlpatterns = [
     path('questions/<int:question_id>/topic/', question_views.get_topic_url, name='get_topic_url'),
     path('topics/', question_views.list_all_topics, name='list_all_topics'),
 
-    path('create_annotation/', annotation_views.create_annotation, name='create_annotation'),
-    path('delete_annotation/<int:annotation_id>/', annotation_views.delete_annotation, name='delete_annotation'),
-    path('edit_annotation/<int:annotation_id>/', annotation_views.edit_annotation, name='edit_annotation'),
-    path('get_annotations_by_language_id/<int:language_qid>/', annotation_views.get_annotations_by_language, name='get_annotations_by_language_id'),
-    path('annotations/all/', annotation_views.get_all_annotations, name='get_all_annotations'),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/django_project_491/django_app/views/annotation_views.py
+++ b/django_project_491/django_app/views/annotation_views.py
@@ -151,7 +151,7 @@ def edit_annotation(request, annotation_id):
     return JsonResponse({'error': 'Invalid request method'}, status=405)
 
 @csrf_exempt
-def get_annotations_by_language(request, language_qid):
+def get_annotations_by_language(request, language_qid, return_data_only=False):
     if request.method == 'GET':
         try:
             # Fetch all annotations with the given language_qid
@@ -186,11 +186,18 @@ def get_annotations_by_language(request, language_qid):
                 }
                 annotations_data.append(annotation_data)
 
+            if return_data_only:
+                return annotations_data
+
             return JsonResponse({'success': 'Annotations retrieved', 'data': annotations_data}, status=200)
 
         except Exception as e:
+            if return_data_only:
+                return []
             return JsonResponse({'error': str(e)}, status=400)
 
+    if return_data_only:
+        return []
     return JsonResponse({'error': 'Invalid request method'}, status=405)
 
 

--- a/django_project_491/django_app/views/utilization_views.py
+++ b/django_project_491/django_app/views/utilization_views.py
@@ -66,7 +66,7 @@ def wiki_search(request, search_strings):
 
 
 # Shows the resulting info of the chosen wiki item
-def wiki_result(response, wiki_id):
+def wiki_result(response, wiki_id, return_data_only=False):
     """
     Retrieve language information from Wikidata and return as a JSON response.
 
@@ -187,6 +187,8 @@ def wiki_result(response, wiki_id):
         'wikipedia': wikipedia_data
     }
 
+    if return_data_only:
+        return final_response
     return JsonResponse(final_response)
 
 

--- a/koduyorum-web/src/SearchResults.js
+++ b/koduyorum-web/src/SearchResults.js
@@ -45,133 +45,143 @@ const SearchResults = () => {
         const topResult = searchResults[0];
         handleSearchResultClick(topResult);
     }
-};
-const handleSearch = async () => {
-    if (!searchQuery) {
-        return;
-    }
-    setIsLoading(true);
-    setSearched(true);
-    const results = await fetchSearchResults(searchQuery.toLowerCase());
-    setSearchResults(results);
-    setIsLoading(false);
-};
-
-const handleClickOutside = (event) => {
-    if (searchDisplayRef.current && !searchDisplayRef.current.contains(event.target)) {
-        setSearched(false);
-    }
-};
-
-const handleSearchResultClick = async (result) => {
-    const wikiIdName = await fetchWikiIdAndName(result.languageLabel.value);
-    const wikiId = wikiIdName[0];
-    const wikiName = wikiIdName[1];
-    console.log("Wiki ID and Name:", wikiId, wikiName);
-    if (wikiId) {
-        console.log("Navigating to:", `/result/${wikiId}/${encodeURIComponent(wikiName)}`);
-        setSearched(false);
-        setSearchQuery("");
-        setSearchResults([]); 
-        navigate(`/result/${wikiId}/${encodeURIComponent(wikiName)}`);
-    } else {
-        console.error("No wiki ID found for search result:", result);
-    }
-};
-
-const handleSearchQueryChange = async (e) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (query) {
-        setIsLoading(true);
-        const results = await fetchSearchResults(query);
-        setSearchResults(results);
-        setSearched(true);
-        setIsLoading(false);
-    } else {
-        setSearchResults([]);
-        setSearched(false);
-    }
-};
-// --------------------------------
-
-
-const fetchWikiIdAndName = async (string) => {
-  try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/search/${encodeURIComponent(string)}`);
-      if (!response.ok) {
-          throw new Error('Network response was not ok');
+  };
+  const handleSearch = async () => {
+      if (!searchQuery) {
+          return;
       }
-      const data = await response.json();
-      // Assuming the API returns an array of results and the first one is the most relevant
-      return [data.results.bindings[0]?.language?.value.split('/').pop(), data.results.bindings[0]?.languageLabel?.value]; // returns [wikiId, wikiName]
-  } catch (error) {
-      console.error("Error fetching wiki ID:", error);
-      return null;
+      setIsLoading(true);
+      setSearched(true);
+      const results = await fetchSearchResults(searchQuery.toLowerCase());
+      setSearchResults(results);
+      setIsLoading(false);
+  };
+
+  const handleClickOutside = (event) => {
+      if (searchDisplayRef.current && !searchDisplayRef.current.contains(event.target)) {
+          setSearched(false);
+      }
+  };
+
+  const handleSearchResultClick = async (result) => {
+      const wikiIdName = await fetchWikiIdAndName(result.languageLabel.value);
+      const wikiId = wikiIdName[0];
+      const wikiName = wikiIdName[1];
+      console.log("Wiki ID and Name:", wikiId, wikiName);
+      if (wikiId) {
+          console.log("Navigating to:", `/result/${wikiId}/${encodeURIComponent(wikiName)}`);
+          setSearched(false);
+          setSearchQuery("");
+          setSearchResults([]); 
+          navigate(`/result/${wikiId}/${encodeURIComponent(wikiName)}`);
+      } else {
+          console.error("No wiki ID found for search result:", result);
+      }
+  };
+
+  const handleSearchQueryChange = async (e) => {
+      const query = e.target.value;
+      setSearchQuery(query);
+
+      if (query) {
+          setIsLoading(true);
+          const results = await fetchSearchResults(query);
+          setSearchResults(results);
+          setSearched(true);
+          setIsLoading(false);
+      } else {
+          setSearchResults([]);
+          setSearched(false);
+      }
+  };
+  // --------------------------------
+
+
+  const fetchWikiIdAndName = async (string) => {
+    try {
+        const response = await fetch(`${process.env.REACT_APP_API_URL}/search/${encodeURIComponent(string)}`);
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        const data = await response.json();
+        // Assuming the API returns an array of results and the first one is the most relevant
+        return [data.results.bindings[0]?.language?.value.split('/').pop(), data.results.bindings[0]?.languageLabel?.value]; // returns [wikiId, wikiName]
+    } catch (error) {
+        console.error("Error fetching wiki ID:", error);
+        return null;
+    }
+  };
+
+  const handleTagClick = async (tag) => {
+      const wikiIdAndName = await fetchWikiIdAndName(tag);
+      const wikiId = wikiIdAndName[0];
+      const wikiName = wikiIdAndName[1];
+      if (wikiId) {
+          navigate(`/result/${wikiId}/${encodeURIComponent(wikiName)}`);
+      } else {
+          console.error("No wiki ID found for tag:", tag);
+      }
+  };
+
+  const fetchPosts = async () => {
+      try {
+          const response = await fetch(`${process.env.REACT_APP_API_URL}/random_questions/`);
+          if (!response.ok) {
+              throw new Error(`HTTP error! Status: ${response.status}`);
+          }
+          const data = await response.json();
+          setPosts(data.questions);
+      } catch (error) {
+          console.error('Error fetching posts:', error.message);
+          setError('Failed to load posts. Please check your network or server configuration.');
+      }
+  };
+
+  const fetchSearchResults = async (query) => {
+      try {
+          const response = await fetch(`${process.env.REACT_APP_API_URL}/search/${encodeURIComponent(query)}`);
+          if (!response.ok) {
+              throw new Error(`HTTP error! Status: ${response.status}`);
+          }
+          const data = await response.json();
+          return data.results.bindings;
+      } catch (error) {
+          console.error('Error fetching search results:', error.message);
+          setError('Failed to load search results. Please check your network or server configuration.');
+          return [];
+      }
   }
-};
-
-const handleTagClick = async (tag) => {
-    const wikiIdAndName = await fetchWikiIdAndName(tag);
-    const wikiId = wikiIdAndName[0];
-    const wikiName = wikiIdAndName[1];
-    if (wikiId) {
-        navigate(`/result/${wikiId}/${encodeURIComponent(wikiName)}`);
-    } else {
-        console.error("No wiki ID found for tag:", tag);
-    }
-};
-
-const fetchPosts = async () => {
-    try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/random_questions/`);
-        if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-        const data = await response.json();
-        setPosts(data.questions);
-    } catch (error) {
-        console.error('Error fetching posts:', error.message);
-        setError('Failed to load posts. Please check your network or server configuration.');
-    }
-};
-
-const fetchSearchResults = async (query) => {
-    try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/search/${encodeURIComponent(query)}`);
-        if (!response.ok) {
-            throw new Error(`HTTP error! Status: ${response.status}`);
-        }
-        const data = await response.json();
-        return data.results.bindings;
-    } catch (error) {
-        console.error('Error fetching search results:', error.message);
-        setError('Failed to load search results. Please check your network or server configuration.');
-        return [];
-    }
-}
 
   const fetchSearchData = async ([wikiId, wikiName]) => {
     try {
       setLoading(true);
       setError(null);
+      console.log("Fetching search data for wiki ID:", encodeURIComponent(wikiId), wikiId.slice(1));
 
-      const infoResponse = await fetch(`${process.env.REACT_APP_API_URL}/result/${encodeURIComponent(wikiId)}`);
-      const questionResponse = await fetch(`${process.env.REACT_APP_API_URL}/list_questions_by_language/${encodeURIComponent(wikiName)}/1`);
-      const annotationResponse = await fetch(`${process.env.REACT_APP_API_URL}/get_annotations_by_language_id/${wikiId.slice(1)}/`);
+      // const infoResponse = await fetch(`${process.env.REACT_APP_API_URL}/result/${encodeURIComponent(wikiId)}`);
+      // const questionResponse = await fetch(`${process.env.REACT_APP_API_URL}/list_questions_by_language/${encodeURIComponent(wikiName)}/1`);
+      // const annotationResponse = await fetch(`${process.env.REACT_APP_API_URL}/get_annotations_by_language_id/${wikiId.slice(1)}/`);
+      
+      const infoQuestionAnnotationResponse = await fetch(`${process.env.REACT_APP_API_URL}/fetch_search_results_at_once/${encodeURIComponent(wikiId)}/${encodeURIComponent(wikiName)}/${(1)}`); 
+      // Feth all data and questions' first page. Because it is default and the user can go to other pages, if there are more than one page.
 
-      if (!infoResponse.ok || !questionResponse.ok) {
+      if (!infoQuestionAnnotationResponse.ok) {
         throw new Error('Failed to load data');
       }
 
-      const infoData = await infoResponse.json();
-      const questionData = await questionResponse.json();      
-      const annotationData = await annotationResponse.json();
-      const questionsArray = questionData.questions;
+      // if (!infoResponse.ok || !questionResponse.ok) {
+      //   throw new Error('Failed to load data');
+      // }
+
+      const infoQuestionAnnotationData = await infoQuestionAnnotationResponse.json();
+      const infoData = infoQuestionAnnotationData.information;
+      const questionData = infoQuestionAnnotationData.questions;      
+      const annotationData = infoQuestionAnnotationData.annotations;
+
+      console.log("annotationData data:", annotationData);
       setInfoData(infoData || { mainInfo: [], instances: [], wikipedia: {} });
-      setQuestionData(questionsArray || []);
-      setAnnotationData(annotationData.data || []);
+      setQuestionData(questionData || []);
+      setAnnotationData(annotationData || []);
     } catch (err) {
       console.error("Error fetching search data:", err);
       setError("Failed to load search data.");
@@ -203,7 +213,7 @@ const fetchSearchResults = async (query) => {
       
       // Add annotated text with tooltip
       annotatedText.push(
-        <span className="annotation" key={annotation_starting_point}>
+        <span className="annotation" key={annotationId}>
           <em>{text.slice(annotation_starting_point, annotation_ending_point)}</em>
           <div className="annotation-tooltip">
             {annotationText}  {/* This will show the annotation text */}


### PR DESCRIPTION
Added parallel fetching for result page by combining three separate API calls (information, questions, and annotations) into a single endpoint. This improves load time and reduces network overhead.
