### PR TITLE
Add pagination support for questions list

### DIFF
--- a/django_project_491/django_app/urls.py
+++ b/django_project_491/django_app/urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
     path('list_questions_by_tags/<str:tags>/<int:page_number>/', question_views.list_questions_by_tags, name='list_questions_by_tags'),
     path('list_questions_by_hotness/<int:page_number>', question_views.list_questions_by_hotness, name='list_questions_by_hotness'),
     path('random_questions/', question_views.random_questions, name='random_questions'),
-    path('get_questions_according_to_filter',question_views.get_questions_according_to_filter, name='get_questions_according_to_filter'),
+    path('get_questions_according_to_filter/<int:page_number>',question_views.get_questions_according_to_filter, name='get_questions_according_to_filter'),
 
 
     path('upvote_object/<str:object_type>/<int:object_id>/', utilization_views.upvote_object, name='upvote_object'),

--- a/django_project_491/django_app/views/question_views.py
+++ b/django_project_491/django_app/views/question_views.py
@@ -1795,7 +1795,6 @@ def get_questions_according_to_filter(request, page_number):
         tags = data.get('tags', [])
         start_date = data.get('startDate') 
         end_date = data.get('endDate')
-        print(data)
         # Start with all questions, ordered by creation date
         questions = Question.objects.all().order_by('-created_at')
         
@@ -1844,7 +1843,6 @@ def get_questions_according_to_filter(request, page_number):
         offset = (page_number - 1) * 10
 
         total_count = questions.count()
-        print(total_count)
         total_pages = (total_count + 9) // 10
 
         # Apply pagination

--- a/django_project_491/django_app/views/question_views.py
+++ b/django_project_491/django_app/views/question_views.py
@@ -665,9 +665,9 @@ def list_questions_by_language_request(request, user_id, language: str, page_num
     if not language:
         return JsonResponse({'error': 'Language parameter is required'}, status=400)
 
-    questions_data = list_questions_by_language(user_id, language)
+    questions_data , page_count= list_questions_by_language(user_id, language, page_number)
 
-    return JsonResponse({'questions': questions_data}, safe=False, status=200)
+    return JsonResponse({'questions': questions_data, 'page_count': page_count}, safe=False, status=200)
 
 
 def list_questions_by_language(user_id: int, language: str, page_number = 1) -> List[Question]:
@@ -684,6 +684,8 @@ def list_questions_by_language(user_id: int, language: str, page_number = 1) -> 
     user = User.objects.get(pk=user_id)
     user_votes = Question_Vote.objects.filter(user_id=user_id).values('question_id', 'vote_type')
     user_votes_dict = {vote['question_id']: vote['vote_type'] for vote in user_votes}
+
+    page_count = (questions.count() + 9) // 10
 
     return [{   
         'id': question.pk,
@@ -702,7 +704,7 @@ def list_questions_by_language(user_id: int, language: str, page_number = 1) -> 
         'is_bookmarked': user.bookmarks.filter(pk=question.pk).exists(),
         'created_at' : question.created_at.strftime('%Y-%m-%d %H:%M:%S'),
         'post_type': question.type    
-    } for question in questions]
+    } for question in questions], page_count
 
 
 
@@ -1397,11 +1399,23 @@ def fetch_all_feed_at_once(request, user_id: int):
             )
             .distinct()[:10]
         )
+
+        # Get total count for preferred questions
+        total_preferred = questions.count()
+
         if len(questions) < 10:
             general_questions = Question.objects.exclude(
-            pk__in=[q.pk for q in questions]
-            ).order_by('-created_at')[:10 - len(questions)]
+                pk__in=[q.pk for q in questions]
+                ).order_by('-created_at')[:10 - len(questions)]
             questions = list(questions) + list(general_questions)
+            total_general = Question.objects.exclude(
+                    pk__in=Question.objects.filter(
+                        Q(language__in=user.known_languages) | Q(tags__overlap=user.interested_topics)
+                    )
+                ).count()
+            total_count = total_preferred + total_general
+        else:
+            total_count = total_preferred
 
         return [
             {
@@ -1423,7 +1437,7 @@ def fetch_all_feed_at_once(request, user_id: int):
                 'post_type': q.type
             }
             for q in questions
-        ]
+        ], (total_count + 9) // 10
 
     def get_question_of_the_day():
         today = timezone.now().date()
@@ -1461,7 +1475,7 @@ def fetch_all_feed_at_once(request, user_id: int):
         future_top_contributors = executor.submit(get_top_5_contributors)
         future_top_tags = executor.submit(get_most_popular_tags)
 
-        questions = future_questions.result()
+        questions, total_page = future_questions.result()
         question_of_the_day = future_question_of_the_day.result()
         top_contributors = future_top_contributors.result()
         top_tags = future_top_tags.result()
@@ -1472,6 +1486,7 @@ def fetch_all_feed_at_once(request, user_id: int):
         'question_of_the_day': question_of_the_day,
         'top_contributors': top_contributors,
         'top_tags': top_tags,
+        'page_count': total_page
     }
 
     # Cache the feed data for a specified amount of time
@@ -1648,15 +1663,15 @@ def fetch_search_results_at_once(request, wiki_id, language, page_number=1):
 
 
         information_result = info_future.result()
-        question_result = questions_future.result()
+        question_result, page_count = questions_future.result()
         annotation_result = annotations_future.result()
         top_contributors_result = top_contributors_future.result()
         top_tags_result = top_tags_future.result()
-    
 
     return JsonResponse({
         'information': information_result,
         'questions': question_result,
+        'page_count': page_count,
         'annotations': annotation_result,
         'top_contributors': top_contributors_result,
         'top_tags': top_tags_result
@@ -1749,7 +1764,7 @@ def fetch_search_results_at_once(request, wiki_id, language, page_number=1):
 @api_view(['POST'])
 @permission_classes([AllowAny])
 @csrf_exempt
-def get_questions_according_to_filter(request):
+def get_questions_according_to_filter(request, page_number):
     """
     Retrieve a list of questions based on various filters provided in the request.
     Args:
@@ -1780,7 +1795,7 @@ def get_questions_according_to_filter(request):
         tags = data.get('tags', [])
         start_date = data.get('startDate') 
         end_date = data.get('endDate')
-        
+        print(data)
         # Start with all questions, ordered by creation date
         questions = Question.objects.all().order_by('-created_at')
         
@@ -1820,8 +1835,14 @@ def get_questions_according_to_filter(request):
                 print("Invalid date format for end_date")
                 pass 
 
-        # We need 10 of them in the frontend
-        questions = questions[:10]
+        offset = (page_number - 1) * 10
+
+        total_count = questions.count()
+        print(total_count)
+        total_pages = (total_count + 9) // 10
+
+        # Apply pagination
+        questions = questions[offset:offset + 10]
 
         questions_data = [{
             'id': q.pk,
@@ -1842,7 +1863,7 @@ def get_questions_according_to_filter(request):
             'post_type': q.type
         } for q in questions]
         
-        return JsonResponse({'questions': questions_data}, safe=False)
+        return JsonResponse({'questions': questions_data, 'total_pages': total_pages}, safe=False)
     except Exception as e:
         return JsonResponse({'error': str(e)}, status=500)
 

--- a/django_project_491/django_app/views/question_views.py
+++ b/django_project_491/django_app/views/question_views.py
@@ -1809,8 +1809,14 @@ def get_questions_according_to_filter(request, page_number):
             
         # Apply language filter
         if language != 'all':
-            questions = questions.filter(language__iexact=language)
-            
+            questions = questions.filter(language__istartswith=language)
+            if not questions.exists():
+                questions = Question.objects.filter(tags__contains=[language.title()])
+                if not questions.exists():
+                    questions = Question.objects.filter(tags__contains=[language.lower()])           
+                if not questions.exists():
+                    questions = Question.objects.filter(tags__contains=[language.upper()])
+
         # Apply tags filter 
         if tags:
             lowercase_tags = [tag.lower() for tag in tags]

--- a/koduyorum-web/src/PageComponents.js
+++ b/koduyorum-web/src/PageComponents.js
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import './Feed.css';
 import Select from 'react-select';
 import { predefinedTags } from './constants/tags';
-import { showNotification } from './NotificationCenter';
 import { languages } from './constants/tags';
 
 // LogoutButton Component
@@ -106,53 +105,13 @@ export const Navbar = ({
 };
 
 // LeftSidebar Component
-export const LeftSidebar = ({ tags, handleTagClick, setPosts, language, top_tags }) => {
-  const [filters, setFilters] = useState({
-    status: 'all',
-    language: language == "" ? "all" : language,
-    tags: [],
-    startDate: '',
-    endDate: ''
-  });
+export const LeftSidebar = ({ tags, handleTagClick, language, top_tags,filters, setFilters, handleApplyFilters }) => {
 
   const handleFilterChange = (filterType, value) => {
     setFilters(prev => ({
       ...prev,
       [filterType]: value
     }));
-  };
-
-  const handleApplyFilters = async () => {
-    if (filters.endDate && filters.startDate && filters.endDate < filters.startDate) {
-      showNotification('End date cannot be before start date');
-      return;
-    }
-    try {
-      const response = await fetch(`${process.env.REACT_APP_API_URL}/get_questions_according_to_filter`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'User-ID': localStorage.getItem('user_id'),
-        },
-        body: JSON.stringify({
-          status: filters.status,
-          language: filters.language,
-          tags: filters.tags,
-          date_range: {
-            start_date: filters.startDate,
-            end_date: filters.endDate
-          }
-        })
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        console.log('Filtered questions:', data);
-        setPosts(data.questions);
-      }
-    } catch (error) {
-      console.error('Error fetching filtered questions:', error);
-    }
   };
 
   return (
@@ -242,7 +201,7 @@ export const LeftSidebar = ({ tags, handleTagClick, setPosts, language, top_tags
         </div>
 
         <button 
-          onClick={handleApplyFilters}
+          onClick={async () => handleApplyFilters(1)}
           className="apply-filters-btn "
         >
           Apply Filters
@@ -251,8 +210,6 @@ export const LeftSidebar = ({ tags, handleTagClick, setPosts, language, top_tags
     </div>
   );
 };
-
-
 
 // RightSidebar Component
 export const RightSidebar = ({ topContributors }) => {


### PR DESCRIPTION
Implemented frontend pagination controls for the questions list to enable users to navigate through multiple pages of content more efficiently. Added page count display and navigation buttons that integrate with the backend pagination API. This enhancement improves the user experience by making it easier to browse through large sets of questions.